### PR TITLE
Topic/xml

### DIFF
--- a/b2btest/__init__.py
+++ b/b2btest/__init__.py
@@ -1,1 +1,1 @@
-from b2btest import runBack2BackProgram
+from b2btest import runBack2BackProgram, runBack2BackProgram_returnSuccess, die

--- a/b2btest/b2btest.py
+++ b/b2btest/b2btest.py
@@ -170,7 +170,7 @@ due to floating point missmatches, use:
 def _caseList(cases) :
 	return "".join(["\t"+case+"\n" for case in cases])
 
-def runBack2BackProgram(datapath, argv, back2BackCases, help=help) :
+def runBack2BackProgram_returnSuccess(datapath, argv, back2BackCases, help=help) :
 
 	"--help" not in sys.argv or die(help, 0)
 
@@ -203,7 +203,10 @@ def runBack2BackProgram(datapath, argv, back2BackCases, help=help) :
 		accept(datapath, back2BackCases, architectureSpecific)
 		sys.exit()
 
-	passB2BTests(datapath, back2BackCases) or die("Tests not passed")
+	return passB2BTests(datapath, back2BackCases)
 
+
+def runBack2BackProgram(datapath, argv, back2BackCases, help=help) :
+	runBack2BackProgram_returnSuccess(datapath, argv, back2BackCases, help) or die("Tests not passed") 
 
 ### End of generic stuff

--- a/b2btest/b2btest.py
+++ b/b2btest/b2btest.py
@@ -231,9 +231,6 @@ def runBack2BackProgram_returnSuccess(datapath, argv, back2BackCases, help=help)
 		accept(datapath, back2BackCases, architectureSpecific)
 		sys.exit()
 
-	if "--xml" in argv :
-		print "XML output required"
-
 	return passB2BTests(datapath, back2BackCases)
 
 def runBack2BackProgram(datapath, argv, back2BackCases, help=help) :

--- a/b2btest/b2btest.py
+++ b/b2btest/b2btest.py
@@ -203,6 +203,9 @@ def runBack2BackProgram(datapath, argv, back2BackCases, help=help) :
 		accept(datapath, back2BackCases, architectureSpecific)
 		sys.exit()
 
+	if "--xml" in argv :
+		print "XML output required"
+
 	passB2BTests(datapath, back2BackCases) or die("Tests not passed")
 
 

--- a/b2btest/diffaudio.py
+++ b/b2btest/diffaudio.py
@@ -77,8 +77,8 @@ def differences(expected, result, diffBase=None) :
 						)
 
 			with diffWriter :
-				resultData = np.empty((hopsize, channels), np.float64)
-				expectedData = np.empty((hopsize, channels), np.float64)
+				resultData = np.zeros((hopsize, channels), np.float64)
+				expectedData = np.zeros((hopsize, channels), np.float64)
 
 				maxdiff      = np.zeros((channels))
 				maxdiffpos   = np.array([None]*channels)

--- a/b2btest/diffaudio.py
+++ b/b2btest/diffaudio.py
@@ -27,18 +27,22 @@ extensions = [
 	'au',
 ]
 
-def differences(expected, result, diffBase=None) :
+def differences(expected, result, diffBase=None, threshold_dBs=-80 , allow_different_duration=False) :
 	import wavefile_audiolab
 	import numpy as np
+
+	mandatory_attributes = [ 
+				'samplerate', 
+				'channels',
+				'frames',
+				] 
+	if allow_different_duration : 
+		mandatory_attributes.remove('frames')
 
 	errors = []
 	with wavefile_audiolab.WaveReader(expected) as expectedReader :
 		with wavefile_audiolab.WaveReader(result) as resultReader :
-			for attribute in [
-				'samplerate',
-				'channels',
-				'frames',
-				] :
+			for attribute in mandatory_attributes :
 				expectedAttribute = getattr(expectedReader, attribute)
 				resultAttribute = getattr(resultReader, attribute)
 				if expectedAttribute != resultAttribute :
@@ -118,7 +122,6 @@ def differences(expected, result, diffBase=None) :
 
 					period += 1
 
-			threshold_dBs = -80.0 # dB
 			threshold_amplitude = 10**(threshold_dBs/20)
 
 			errors += [
@@ -188,6 +191,7 @@ def cummulativeCompare(values, pos, diff, offset) :
 
 if __name__ == '__main__' :
 
+	import sys
 	diffs = differences(*sys.argv[1:])
 	if not diffs : print "Ok"; sys.exit(0)
 	for d in diffs :

--- a/b2btest/diffaudio.py
+++ b/b2btest/diffaudio.py
@@ -28,12 +28,12 @@ extensions = [
 ]
 
 def differences(expected, result, diffBase=None) :
-	import wavefile
+	import wavefile_audiolab
 	import numpy as np
 
 	errors = []
-	with wavefile.WaveReader(expected) as expectedReader :
-		with wavefile.WaveReader(result) as resultReader :
+	with wavefile_audiolab.WaveReader(expected) as expectedReader :
+		with wavefile_audiolab.WaveReader(result) as resultReader :
 			for attribute in [
 				'samplerate',
 				'channels',
@@ -71,7 +71,7 @@ def differences(expected, result, diffBase=None) :
 				import os.path
 				extension = os.path.splitext(result)[-1]
 				diffwav = diffBase+extension
-				diffWriter = wavefile.WaveWriter(diffwav, 
+				diffWriter = wavefile_audiolab.WaveWriter(diffwav, 
 						channels = channels,
 						samplerate = expectedReader.samplerate,
 						)

--- a/b2btest/diffaudioTest.py
+++ b/b2btest/diffaudioTest.py
@@ -148,8 +148,8 @@ class MultiChannelDiffTests(unittest.TestCase) :
 	def savewav(self, data, filename, samplerate) :
 		import os
 		assert not os.access(filename, os.F_OK), "Test temporary file already existed: %s"%filename
-		import wavefile
-		with wavefile.WaveWriter(
+		import wavefile_audiolab
+		with wavefile_audiolab.WaveWriter(
 				filename,
 				samplerate=samplerate,
 				channels=data.shape[1]

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -1,46 +1,90 @@
 
 from xml.dom.minidom import Document, Element
 
-class TestCase(Element) :
+class TestCase() :
 	def __init__(self) :
-		Element.__init__(self, "testcase")
-		Element.setAttribute(self, "name", "")
-		Element.setAttribute(self, "status", "")
-		Element.setAttribute(self, "time", "")
-		Element.setAttribute(self, "classname", "")
+		self._element = Element("testcase")
+		self._element.setAttribute("name", "")
+		self._element.setAttribute("status", "")
+		self._element.setAttribute("time", "0")
+		self._element.setAttribute("classname", "")
 
-	def appendChild(self, node) :
-		# TODO: raise exception
-		pass
+	def setAttribute(self, attribute, value) :
+		self._element.setAttribute(attribute, value)
 
-class TestSuite(Element) :
+	def getAttribute(self, attribute) :
+		return self._element.getAttribute(attribute)
+
+class TestSuite() :
 	def __init__(self) :
-		Element.__init__(self, "testsuite")
+		self._element = Element("testsuite")
+		self._element.setAttribute("name", "")
+		self._element.setAttribute("tests", "0")
+		self._element.setAttribute("failures", "0")
+		self._element.setAttribute("disabled", "0")
+		self._element.setAttribute("errors", "0")
+		self._element.setAttribute("time", "0")
+
+
+	def getAttribute(self, attribute) :
+		return self._element.getAttribute(attribute)
 
 	def appendChild(self, testcase) :
 		if not isinstance(testcase, TestCase) :
 			raise TypeError()
-		Element.appendChild(self, testcase)
+		self._element.appendChild(testcase._element)
+		self._element.setAttribute("tests", str(int(self._element.getAttribute("tests")) + 1)) 
+		self._element.setAttribute("time", str(int(self._element.getAttribute("time")) + int(testcase.getAttribute("time"))))
+		status = testcase.getAttribute("status")
+		if status == "notrun" :
+			self._element.setAttribute(self, "disabled",  str(int(self._element.getAttribute(self, "disabled")) + 1))
 
-class TestSuites(Element) :
+class TestSuites() :
 	def __init__(self) :
-		Element.__init__(self, "testsuites")
+		self._element = Element("testsuites")
+		self._element.setAttribute("name", "")
+		self._element.setAttribute("tests", "0")
+		self._element.setAttribute("failures", "0")
+		self._element.setAttribute("disabled", "0")
+		self._element.setAttribute("errors", "0")
+		self._element.setAttribute("time", "0")
 
 	def appendChild(self, testsuite) :
 		if not isinstance(testsuite, TestSuite) :
 			raise TypeError()
-		Element.appendChild(self, testsuite)
+		self._element.appendChild(testsuite._element)
+		self._element.setAttribute("tests", str(int(self._element.getAttribute("tests")) + int(testsuite.getAttribute("tests"))))
+		self._element.setAttribute("failures", str(int(self._element.getAttribute("failures")) + int(testsuite.getAttribute("failures"))))
+		self._element.setAttribute("disabled", str(int(self._element.getAttribute("disabled")) + int(testsuite.getAttribute("disabled"))))
+		self._element.setAttribute("errors", str(int(self._element.getAttribute("errors")) + int(testsuite.getAttribute("errors"))))
+		self._element.setAttribute("time", str(int(self._element.getAttribute("time")) + int(testsuite.getAttribute("time"))))
 
-class JUnitDocument(Document) :
+class JUnitDocument() :
 	def __init__(self) :
-		Document.__init__(self)
+		self._document = Document()
+
+	def appendChild(self, testsuites) :
+		if not isinstance(testsuites, TestSuites) :
+			raise TypeError()
+		self._document.appendChild(testsuites._element)
+
+	def toxml(self) :
+		return self._document.toprettyxml()
+
+
 
 
 if __name__ == "__main__" :
 	doc = JUnitDocument()
 
+	testcase = TestCase()
+	testsuite = TestSuite()
 	testsuites = TestSuites()
-	testsuites.appendChild(TestSuite())
+
+	testsuite.appendChild(testcase)
+	testsuite.appendChild(TestCase())
+
+	testsuites.appendChild(testsuite)
 
 	doc.appendChild(testsuites)
-	print doc.toprettyxml()
+	print doc.toxml()

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -1,79 +1,46 @@
 
-from xml.dom.minidom import Document
+from xml.dom.minidom import Document, Element
 
-class TestCase :
+class TestCase(Element) :
 	def __init__(self) :
-		self.name = ""
-		self.status = ""
-		self.time = ""
-		self.classname = ""
+		Element.__init__(self, "testcase")
+		Element.setAttribute(self, "name", "")
+		Element.setAttribute(self, "status", "")
+		Element.setAttribute(self, "time", "")
+		Element.setAttribute(self, "classname", "")
 
-	def toElement(self) :
-		element = Document().createElement("testcase")
-		element.setAttribute("name", self.name)
-		element.setAttribute("status", self.status)
-		element.setAttribute("time", self.time)
-		element.setAttribute("classname", self.classname)
-		return element
+	def appendChild(self, node) :
+		# TODO: raise exception
+		pass
 
-class TestSuite :
+class TestSuite(Element) :
 	def __init__(self) :
-		self.name = ""
-		self.failures = 0
-		self.disabled = 0
-		self.errors = 0
-		self.time = 0
-		self.tests = 0
-		self._testcases = []
+		Element.__init__(self, "testsuite")
 
-	def appendTestCase(self, testcase) :
+	def appendChild(self, testcase) :
 		if not isinstance(testcase, TestCase) :
-			raise TypeError("Not a TestCase instance")
+			raise TypeError()
+		Element.appendChild(self, testcase)
 
-		self._testcases.append(testcase)
-		self.tests += 1;
-
-	def toElement(self) :
-		element = Document().createElement("testsuite")
-		element.setAttribute("name", self.name)
-		element.setAttribute("tests", str(self.tests))
-		element.setAttribute("failures", str(self.failures))
-		element.setAttribute("disabled", str(self.disabled))
-#		element.setAttribute("errors", self.errors)
-#		element.setAttribute("time", self.time)
-		for testcase in self._testcases :
-			element.appendChild(testcase.toElement())
-		return element;
-
-class JUnitTestXMLOutput :
+class TestSuites(Element) :
 	def __init__(self) :
-		self._testsuites = []
+		Element.__init__(self, "testsuites")
 
-	def appendTestSuite(self, testsuite) :
+	def appendChild(self, testsuite) :
 		if not isinstance(testsuite, TestSuite) :
-			raise TypeError("Not a TestSuite instance")
-		self._testsuites.append(testsuite)
+			raise TypeError()
+		Element.appendChild(self, testsuite)
 
-	def toXML(self) :
-		doc = Document()
-		element = doc.createElement("testsuites")
-		element.setAttribute("tests", str(sum([testsuite.tests for testsuite in self._testsuites])))
+class JUnitDocument(Document) :
+	def __init__(self) :
+		Document.__init__(self)
 
-		for testsuite in self._testsuites :
-			element.appendChild(testsuite.toElement())
-
-		doc.appendChild(element)
-		return doc
 
 if __name__ == "__main__" :
-	xml = JUnitTestXMLOutput()
+	doc = Document()
 
-	testsuite = TestSuite()
-	testsuite.appendTestCase(TestCase())
-	testsuite.appendTestCase(TestCase())
-	testsuite.appendTestCase(TestCase())
-	testsuite.appendTestCase(TestCase())
+	testsuites = TestSuites()
+	testsuites.appendChild(TestSuite())
 
-	xml.appendTestSuite(testsuite)
-	
-	print xml.toXML().toprettyxml()
+	doc.appendChild(testsuites)
+	print doc.toprettyxml()

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -11,6 +11,7 @@ class TestCase() :
 		self._element.setAttribute("status", status)
 		self._element.setAttribute("time", time)
 		self._element.setAttribute("classname", classname)
+		self.failed = False
 
 	def attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
@@ -20,6 +21,7 @@ class TestCase() :
 		failure.setAttribute("message", message)
 		failure.setAttribute("type", "")
 		self._element.appendChild(failure)
+		self.failed = True
 
 
 class TestSuite() :
@@ -41,11 +43,13 @@ class TestSuite() :
 			raise TypeError()
 
 		self._element.appendChild(testcase._element)
-		self._element.setAttribute("tests", str(float(self.attrib("tests")) + 1)) 
+		self._element.setAttribute("tests", str(int(self.attrib("tests")) + 1)) 
 		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testcase.attrib("time"))))
 		status = testcase.attrib("status")
 		if status == "notrun" :
-			self._element.setAttribute(self, "disabled",  str(float(self.attrib(self, "disabled")) + 1))
+			self._element.setAttribute("disabled",  str(int(self.attrib("disabled")) + 1))
+		if testcase.failed == True :
+			self._element.setAttribute("failures", str(int(self.attrib("failures")) + 1))
 
 
 class JUnitDocument() :
@@ -59,16 +63,16 @@ class JUnitDocument() :
 		self._element.setAttribute("time", "0")
 
 	def attrib(self, attribute) :
-		return self._element.getattribute(attribute)
+		return self._element.getAttribute(attribute)
 
 	def appendTestSuite(self, testsuite) :
 		if not isinstance(testsuite, TestSuite) :
 			raise TypeError()
 		self._element.appendChild(testsuite._element)
-		self._element.setAttribute("tests", str(float(self.attrib("tests")) + float(testsuite.attrib("tests"))))
-		self._element.setAttribute("failures", str(float(self.attrib("failures")) + float(testsuite.attrib("failures"))))
-		self._element.setAttribute("disabled", str(float(self.attrib("disabled")) + float(testsuite.attrib("disabled"))))
-		self._element.setAttribute("errors", str(float(self.attrib("errors")) + float(testsuite.attrib("errors"))))
+		self._element.setAttribute("tests", str(int(self.attrib("tests")) + int(testsuite.attrib("tests"))))
+		self._element.setAttribute("failures", str(int(self.attrib("failures")) + int(testsuite.attrib("failures"))))
+		self._element.setAttribute("disabled", str(int(self.attrib("disabled")) + int(testsuite.attrib("disabled"))))
+		self._element.setAttribute("errors", str(int(self.attrib("errors")) + int(testsuite.attrib("errors"))))
 		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testsuite.attrib("time"))))
 
 	def toxml(self) :
@@ -80,9 +84,13 @@ class JUnitDocument() :
 if __name__ == "__main__" :
 	doc = JUnitDocument("First")
 
+	testcase = TestCase("test0", "notrun", "1", "class")
+	testcase.appendFailure("failure message")
+
 	testsuite = TestSuite("suite0")
 	testsuite.appendTestCase(TestCase("test1", "run", "10", "class1"))
-	testsuite.appendTestCase(TestCase("test1", "run", "10", "class1"))
+	testsuite.appendTestCase(TestCase("test2", "run", "10", "class1"))
+	testsuite.appendTestCase(testcase)
 
 	doc.appendTestSuite(TestSuite("suite1"))
 	doc.appendTestSuite(testsuite)

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -2,23 +2,20 @@
 from xml.dom.minidom import Document, Element
 
 class TestCase() :
-	def __init__(self) :
+	def __init__(self, name, status, time, classname) :
 		self._element = Element("testcase")
-		self._element.setAttribute("name", "")
-		self._element.setAttribute("status", "")
-		self._element.setAttribute("time", "0")
-		self._element.setAttribute("classname", "")
-
-	def setAttribute(self, attribute, value) :
-		self._element.setAttribute(attribute, value)
+		self._element.setAttribute("name", name)
+		self._element.setAttribute("status", status)
+		self._element.setAttribute("time", time)
+		self._element.setAttribute("classname", classname)
 
 	def getAttribute(self, attribute) :
 		return self._element.getAttribute(attribute)
 
 class TestSuite() :
-	def __init__(self) :
+	def __init__(self, name) :
 		self._element = Element("testsuite")
-		self._element.setAttribute("name", "")
+		self._element.setAttribute("name", name)
 		self._element.setAttribute("tests", "0")
 		self._element.setAttribute("failures", "0")
 		self._element.setAttribute("disabled", "0")
@@ -29,7 +26,7 @@ class TestSuite() :
 	def getAttribute(self, attribute) :
 		return self._element.getAttribute(attribute)
 
-	def appendChild(self, testcase) :
+	def appendTestCase(self, testcase) :
 		if not isinstance(testcase, TestCase) :
 			raise TypeError()
 		self._element.appendChild(testcase._element)
@@ -39,17 +36,20 @@ class TestSuite() :
 		if status == "notrun" :
 			self._element.setAttribute(self, "disabled",  str(int(self._element.getAttribute(self, "disabled")) + 1))
 
-class TestSuites() :
-	def __init__(self) :
+class JUnitDocument() :
+	def __init__(self, name) :
 		self._element = Element("testsuites")
-		self._element.setAttribute("name", "")
+		self._element.setAttribute("name", name)
 		self._element.setAttribute("tests", "0")
 		self._element.setAttribute("failures", "0")
 		self._element.setAttribute("disabled", "0")
 		self._element.setAttribute("errors", "0")
 		self._element.setAttribute("time", "0")
 
-	def appendChild(self, testsuite) :
+	def getAttribute(self, attribute) :
+		return self._element.getAttribute(attribute)
+
+	def appendTestSuite(self, testsuite) :
 		if not isinstance(testsuite, TestSuite) :
 			raise TypeError()
 		self._element.appendChild(testsuite._element)
@@ -59,32 +59,20 @@ class TestSuites() :
 		self._element.setAttribute("errors", str(int(self._element.getAttribute("errors")) + int(testsuite.getAttribute("errors"))))
 		self._element.setAttribute("time", str(int(self._element.getAttribute("time")) + int(testsuite.getAttribute("time"))))
 
-class JUnitDocument() :
-	def __init__(self) :
-		self._document = Document()
-
-	def appendChild(self, testsuites) :
-		if not isinstance(testsuites, TestSuites) :
-			raise TypeError()
-		self._document.appendChild(testsuites._element)
-
 	def toxml(self) :
-		return self._document.toprettyxml()
-
-
+		doc = Document()
+		doc.appendChild(self._element)
+		return doc.toprettyxml()
 
 
 if __name__ == "__main__" :
-	doc = JUnitDocument()
+	doc = JUnitDocument("First")
 
-	testcase = TestCase()
-	testsuite = TestSuite()
-	testsuites = TestSuites()
+	testsuite = TestSuite("suite0")
+	testsuite.appendTestCase(TestCase("test1", "run", "10", "class1"))
+	testsuite.appendTestCase(TestCase("test1", "run", "10", "class1"))
 
-	testsuite.appendChild(testcase)
-	testsuite.appendChild(TestCase())
+	doc.appendTestSuite(TestSuite("suite1"))
+	doc.appendTestSuite(testsuite)
 
-	testsuites.appendChild(testsuite)
-
-	doc.appendChild(testsuites)
 	print doc.toxml()

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -1,20 +1,27 @@
-
 import xml.dom.minidom as MD
 
-class TestCase() :
-	def __init__(self, name, status, time, classname) :
-		if float(time) < 0.0:
+class TestCase :
+	def __init__(self, name) :
+		if not name :
 			raise ValueError
-		
+
 		self._element = MD.Element("testcase")
 		self._element.setAttribute("name", name)
-		self._element.setAttribute("status", status)
-		self._element.setAttribute("time", time)
-		self._element.setAttribute("classname", classname)
+		self._element.setAttribute("status", "run")
+		self._element.setAttribute("time", "0")
+		self._element.setAttribute("classname", "")
 		self.failed = False
 
-	def attrib(self, attribute) :
+	def _attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
+
+	def setTime(self, time) :
+		if float(time) < 0.0 :
+			raise ValueError
+		self._element.setAttribute("time", str(time))
+
+	def setClassname(self, classname) :
+		self._element.setAttribute("classname", classname)	
 
 	def appendFailure(self, message) :
 		failure = MD.Element("failure")
@@ -35,7 +42,7 @@ class TestSuite() :
 		self._element.setAttribute("time", "0")
 
 
-	def attrib(self, attribute) :
+	def _attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
 
 	def appendTestCase(self, testcase) :
@@ -43,13 +50,13 @@ class TestSuite() :
 			raise TypeError()
 
 		self._element.appendChild(testcase._element)
-		self._element.setAttribute("tests", str(int(self.attrib("tests")) + 1)) 
-		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testcase.attrib("time"))))
-		status = testcase.attrib("status")
+		self._element.setAttribute("tests", str(int(self._attrib("tests")) + 1)) 
+		self._element.setAttribute("time", str(float(self._attrib("time")) + float(testcase._attrib("time"))))
+		status = testcase._attrib("status")
 		if status == "notrun" :
-			self._element.setAttribute("disabled",  str(int(self.attrib("disabled")) + 1))
+			self._element.setAttribute("disabled",  str(int(self._attrib("disabled")) + 1))
 		if testcase.failed == True :
-			self._element.setAttribute("failures", str(int(self.attrib("failures")) + 1))
+			self._element.setAttribute("failures", str(int(self._attrib("failures")) + 1))
 
 
 class JUnitDocument() :
@@ -62,18 +69,18 @@ class JUnitDocument() :
 		self._element.setAttribute("errors", "0")
 		self._element.setAttribute("time", "0")
 
-	def attrib(self, attribute) :
+	def _attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
 
 	def appendTestSuite(self, testsuite) :
 		if not isinstance(testsuite, TestSuite) :
 			raise TypeError()
 		self._element.appendChild(testsuite._element)
-		self._element.setAttribute("tests", str(int(self.attrib("tests")) + int(testsuite.attrib("tests"))))
-		self._element.setAttribute("failures", str(int(self.attrib("failures")) + int(testsuite.attrib("failures"))))
-		self._element.setAttribute("disabled", str(int(self.attrib("disabled")) + int(testsuite.attrib("disabled"))))
-		self._element.setAttribute("errors", str(int(self.attrib("errors")) + int(testsuite.attrib("errors"))))
-		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testsuite.attrib("time"))))
+		self._element.setAttribute("tests", str(int(self._attrib("tests")) + int(testsuite._attrib("tests"))))
+		self._element.setAttribute("failures", str(int(self._attrib("failures")) + int(testsuite._attrib("failures"))))
+		self._element.setAttribute("disabled", str(int(self._attrib("disabled")) + int(testsuite._attrib("disabled"))))
+		self._element.setAttribute("errors", str(int(self._attrib("errors")) + int(testsuite._attrib("errors"))))
+		self._element.setAttribute("time", str(float(self._attrib("time")) + float(testsuite._attrib("time"))))
 
 	def toxml(self) :
 		doc = MD.Document()
@@ -82,17 +89,21 @@ class JUnitDocument() :
 
 
 if __name__ == "__main__" :
-	doc = JUnitDocument("First")
+	doc = JUnitDocument("MyTests")
 
-	testcase = TestCase("test0", "notrun", "1", "class")
+	testsuite = TestSuite("testsuite_name")
+
+	testcase = TestCase("testcase_name")
+	testcase.setTime(1.3)
+	testcase.setClassname("testcase_classname")
 	testcase.appendFailure("failure message")
 
-	testsuite = TestSuite("suite0")
-	testsuite.appendTestCase(TestCase("test1", "run", "10", "class1"))
-	testsuite.appendTestCase(TestCase("test2", "run", "10", "class1"))
-	testsuite.appendTestCase(testcase)
+	testcase1 = TestCase("testcase1_name")
+	testcase1.setTime(0.3)
 
-	doc.appendTestSuite(TestSuite("suite1"))
+	testsuite.appendTestCase(testcase)
+	testsuite.appendTestCase(testcase1)
+
 	doc.appendTestSuite(testsuite)
 
 	print doc.toxml()

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -15,6 +15,12 @@ class TestCase() :
 	def attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
 
+	def appendFailure(self, message) :
+		failure = MD.Element("failure")
+		failure.setAttribute("message", message)
+		failure.setAttribute("type", "")
+		self._element.appendChild(failure)
+
 
 class TestSuite() :
 	def __init__(self, name) :

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -9,7 +9,7 @@ class TestCase() :
 		self._element = Element("testcase")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("status", status)
-		self._element.setAttribute("time", str(int(time)))
+		self._element.setAttribute("time", str(time))
 		self._element.setAttribute("classname", classname)
 
 	def getAttribute(self, attribute) :

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -37,7 +37,7 @@ class JUnitDocument(Document) :
 
 
 if __name__ == "__main__" :
-	doc = Document()
+	doc = JUnitDocument()
 
 	testsuites = TestSuites()
 	testsuites.appendChild(TestSuite())

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -1,0 +1,79 @@
+
+from xml.dom.minidom import Document
+
+class TestCase :
+	def __init__(self) :
+		self.name = ""
+		self.status = ""
+		self.time = ""
+		self.classname = ""
+
+	def toElement(self) :
+		element = Document().createElement("testcase")
+		element.setAttribute("name", self.name)
+		element.setAttribute("status", self.status)
+		element.setAttribute("time", self.time)
+		element.setAttribute("classname", self.classname)
+		return element
+
+class TestSuite :
+	def __init__(self) :
+		self.name = ""
+		self.failures = 0
+		self.disabled = 0
+		self.errors = 0
+		self.time = 0
+		self.tests = 0
+		self._testcases = []
+
+	def appendTestCase(self, testcase) :
+		if not isinstance(testcase, TestCase) :
+			raise TypeError("Not a TestCase instance")
+
+		self._testcases.append(testcase)
+		self.tests += 1;
+
+	def toElement(self) :
+		element = Document().createElement("testsuite")
+		element.setAttribute("name", self.name)
+		element.setAttribute("tests", str(self.tests))
+		element.setAttribute("failures", str(self.failures))
+		element.setAttribute("disabled", str(self.disabled))
+#		element.setAttribute("errors", self.errors)
+#		element.setAttribute("time", self.time)
+		for testcase in self._testcases :
+			element.appendChild(testcase.toElement())
+		return element;
+
+class JUnitTestXMLOutput :
+	def __init__(self) :
+		self._testsuites = []
+
+	def appendTestSuite(self, testsuite) :
+		if not isinstance(testsuite, TestSuite) :
+			raise TypeError("Not a TestSuite instance")
+		self._testsuites.append(testsuite)
+
+	def toXML(self) :
+		doc = Document()
+		element = doc.createElement("testsuites")
+		element.setAttribute("tests", str(sum([testsuite.tests for testsuite in self._testsuites])))
+
+		for testsuite in self._testsuites :
+			element.appendChild(testsuite.toElement())
+
+		doc.appendChild(element)
+		return doc
+
+if __name__ == "__main__" :
+	xml = JUnitTestXMLOutput()
+
+	testsuite = TestSuite()
+	testsuite.appendTestCase(TestCase())
+	testsuite.appendTestCase(TestCase())
+	testsuite.appendTestCase(TestCase())
+	testsuite.appendTestCase(TestCase())
+
+	xml.appendTestSuite(testsuite)
+	
+	print xml.toXML().toprettyxml()

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -9,7 +9,7 @@ class TestCase :
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("status", "run")
 		self._element.setAttribute("time", "0")
-		self._element.setAttribute("classname", "")
+		#self._element.setAttribute("classname", "")
 		self.failed = False
 
 	def _attrib(self, attribute) :
@@ -20,7 +20,7 @@ class TestCase :
 			raise ValueError
 		self._element.setAttribute("time", str(time))
 
-	def setClassname(self, classname) :
+	def _setClassname(self, classname) :
 		self._element.setAttribute("classname", classname)	
 
 	def appendFailure(self, message) :
@@ -52,6 +52,7 @@ class TestSuite() :
 		self._element.appendChild(testcase._element)
 		self._element.setAttribute("tests", str(int(self._attrib("tests")) + 1)) 
 		self._element.setAttribute("time", str(float(self._attrib("time")) + float(testcase._attrib("time"))))
+		testcase._setClassname(self._attrib("name"))
 		status = testcase._attrib("status")
 		if status == "notrun" :
 			self._element.setAttribute("disabled",  str(int(self._attrib("disabled")) + 1))

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -14,6 +14,7 @@ class TestCase() :
 	def attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
 
+
 class TestSuite() :
 	def __init__(self, name) :
 		self._element = MD.Element("testsuite")
@@ -37,6 +38,7 @@ class TestSuite() :
 		status = testcase.attrib("status")
 		if status == "notrun" :
 			self._element.setAttribute(self, "disabled",  str(float(self.attrib(self, "disabled")) + 1))
+
 
 class JUnitDocument() :
 	def __init__(self, name) :

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -3,13 +3,15 @@ from xml.dom.minidom import Document, Element
 
 class TestCase() :
 	def __init__(self, name, status, time, classname) :
+		if not time.isdigit():
+			raise ValueError()
 		self._element = Element("testcase")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("status", status)
-		self._element.setAttribute("time", str(float(time)))
+		self._element.setAttribute("time", time)
 		self._element.setAttribute("classname", classname)
 
-	def getAttribute(self, attribute) :
+	def attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
 
 class TestSuite() :
@@ -23,18 +25,18 @@ class TestSuite() :
 		self._element.setAttribute("time", "0")
 
 
-	def getAttribute(self, attribute) :
+	def attrib(self, attribute) :
 		return self._element.getAttribute(attribute)
 
 	def appendTestCase(self, testcase) :
 		if not isinstance(testcase, TestCase) :
 			raise TypeError()
 		self._element.appendChild(testcase._element)
-		self._element.setAttribute("tests", str(float(self._element.getAttribute("tests")) + 1)) 
-		self._element.setAttribute("time", str(float(self._element.getAttribute("time")) + float(testcase.getAttribute("time"))))
-		status = testcase.getAttribute("status")
+		self._element.setAttribute("tests", str(float(self.attrib("tests")) + 1)) 
+		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testcase.attrib("time"))))
+		status = testcase.attrib("status")
 		if status == "notrun" :
-			self._element.setAttribute(self, "disabled",  str(float(self._element.getAttribute(self, "disabled")) + 1))
+			self._element.setAttribute(self, "disabled",  str(float(self.attrib(self, "disabled")) + 1))
 
 class JUnitDocument() :
 	def __init__(self, name) :
@@ -46,18 +48,18 @@ class JUnitDocument() :
 		self._element.setAttribute("errors", "0")
 		self._element.setAttribute("time", "0")
 
-	def getAttribute(self, attribute) :
-		return self._element.getAttribute(attribute)
+	def attrib(self, attribute) :
+		return self._element.getattribute(attribute)
 
 	def appendTestSuite(self, testsuite) :
 		if not isinstance(testsuite, TestSuite) :
 			raise TypeError()
 		self._element.appendChild(testsuite._element)
-		self._element.setAttribute("tests", str(float(self._element.getAttribute("tests")) + float(testsuite.getAttribute("tests"))))
-		self._element.setAttribute("failures", str(float(self._element.getAttribute("failures")) + float(testsuite.getAttribute("failures"))))
-		self._element.setAttribute("disabled", str(float(self._element.getAttribute("disabled")) + float(testsuite.getAttribute("disabled"))))
-		self._element.setAttribute("errors", str(float(self._element.getAttribute("errors")) + float(testsuite.getAttribute("errors"))))
-		self._element.setAttribute("time", str(float(self._element.getAttribute("time")) + float(testsuite.getAttribute("time"))))
+		self._element.setAttribute("tests", str(float(self.attrib("tests")) + float(testsuite.attrib("tests"))))
+		self._element.setAttribute("failures", str(float(self.attrib("failures")) + float(testsuite.attrib("failures"))))
+		self._element.setAttribute("disabled", str(float(self.attrib("disabled")) + float(testsuite.attrib("disabled"))))
+		self._element.setAttribute("errors", str(float(self.attrib("errors")) + float(testsuite.attrib("errors"))))
+		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testsuite.attrib("time"))))
 
 	def toxml(self) :
 		doc = Document()

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -3,8 +3,9 @@ import xml.dom.minidom as MD
 
 class TestCase() :
 	def __init__(self, name, status, time, classname) :
-		if not time.isdigit():
-			raise ValueError()
+		if float(time) < 0.0:
+			raise ValueError
+		
 		self._element = MD.Element("testcase")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("status", status)
@@ -32,6 +33,7 @@ class TestSuite() :
 	def appendTestCase(self, testcase) :
 		if not isinstance(testcase, TestCase) :
 			raise TypeError()
+
 		self._element.appendChild(testcase._element)
 		self._element.setAttribute("tests", str(float(self.attrib("tests")) + 1)) 
 		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testcase.attrib("time"))))

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -3,10 +3,13 @@ from xml.dom.minidom import Document, Element
 
 class TestCase() :
 	def __init__(self, name, status, time, classname) :
+		if not time.isdigit():
+			raise ValueError
+
 		self._element = Element("testcase")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("status", status)
-		self._element.setAttribute("time", time)
+		self._element.setAttribute("time", str(int(time)))
 		self._element.setAttribute("classname", classname)
 
 	def getAttribute(self, attribute) :

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -1,11 +1,11 @@
 
-from xml.dom.minidom import Document, Element
+import xml.dom.minidom as MD
 
 class TestCase() :
 	def __init__(self, name, status, time, classname) :
 		if not time.isdigit():
 			raise ValueError()
-		self._element = Element("testcase")
+		self._element = MD.Element("testcase")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("status", status)
 		self._element.setAttribute("time", time)
@@ -16,7 +16,7 @@ class TestCase() :
 
 class TestSuite() :
 	def __init__(self, name) :
-		self._element = Element("testsuite")
+		self._element = MD.Element("testsuite")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("tests", "0")
 		self._element.setAttribute("failures", "0")
@@ -40,7 +40,7 @@ class TestSuite() :
 
 class JUnitDocument() :
 	def __init__(self, name) :
-		self._element = Element("testsuites")
+		self._element = MD.Element("testsuites")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("tests", "0")
 		self._element.setAttribute("failures", "0")
@@ -62,7 +62,7 @@ class JUnitDocument() :
 		self._element.setAttribute("time", str(float(self.attrib("time")) + float(testsuite.attrib("time"))))
 
 	def toxml(self) :
-		doc = Document()
+		doc = MD.Document()
 		doc.appendChild(self._element)
 		return doc.toprettyxml()
 

--- a/b2btest/junitoutput.py
+++ b/b2btest/junitoutput.py
@@ -3,13 +3,10 @@ from xml.dom.minidom import Document, Element
 
 class TestCase() :
 	def __init__(self, name, status, time, classname) :
-		if not time.isdigit():
-			raise ValueError
-
 		self._element = Element("testcase")
 		self._element.setAttribute("name", name)
 		self._element.setAttribute("status", status)
-		self._element.setAttribute("time", str(time))
+		self._element.setAttribute("time", str(float(time)))
 		self._element.setAttribute("classname", classname)
 
 	def getAttribute(self, attribute) :
@@ -33,11 +30,11 @@ class TestSuite() :
 		if not isinstance(testcase, TestCase) :
 			raise TypeError()
 		self._element.appendChild(testcase._element)
-		self._element.setAttribute("tests", str(int(self._element.getAttribute("tests")) + 1)) 
-		self._element.setAttribute("time", str(int(self._element.getAttribute("time")) + int(testcase.getAttribute("time"))))
+		self._element.setAttribute("tests", str(float(self._element.getAttribute("tests")) + 1)) 
+		self._element.setAttribute("time", str(float(self._element.getAttribute("time")) + float(testcase.getAttribute("time"))))
 		status = testcase.getAttribute("status")
 		if status == "notrun" :
-			self._element.setAttribute(self, "disabled",  str(int(self._element.getAttribute(self, "disabled")) + 1))
+			self._element.setAttribute(self, "disabled",  str(float(self._element.getAttribute(self, "disabled")) + 1))
 
 class JUnitDocument() :
 	def __init__(self, name) :
@@ -56,11 +53,11 @@ class JUnitDocument() :
 		if not isinstance(testsuite, TestSuite) :
 			raise TypeError()
 		self._element.appendChild(testsuite._element)
-		self._element.setAttribute("tests", str(int(self._element.getAttribute("tests")) + int(testsuite.getAttribute("tests"))))
-		self._element.setAttribute("failures", str(int(self._element.getAttribute("failures")) + int(testsuite.getAttribute("failures"))))
-		self._element.setAttribute("disabled", str(int(self._element.getAttribute("disabled")) + int(testsuite.getAttribute("disabled"))))
-		self._element.setAttribute("errors", str(int(self._element.getAttribute("errors")) + int(testsuite.getAttribute("errors"))))
-		self._element.setAttribute("time", str(int(self._element.getAttribute("time")) + int(testsuite.getAttribute("time"))))
+		self._element.setAttribute("tests", str(float(self._element.getAttribute("tests")) + float(testsuite.getAttribute("tests"))))
+		self._element.setAttribute("failures", str(float(self._element.getAttribute("failures")) + float(testsuite.getAttribute("failures"))))
+		self._element.setAttribute("disabled", str(float(self._element.getAttribute("disabled")) + float(testsuite.getAttribute("disabled"))))
+		self._element.setAttribute("errors", str(float(self._element.getAttribute("errors")) + float(testsuite.getAttribute("errors"))))
+		self._element.setAttribute("time", str(float(self._element.getAttribute("time")) + float(testsuite.getAttribute("time"))))
 
 	def toxml(self) :
 		doc = Document()

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -4,21 +4,15 @@ import junitoutput as JU
 class TestCaseTest(unittest.TestCase):
 
 	def test_creation(self):
-		JU.TestCase("name", "status", "1.0", "classname")
+		JU.TestCase("name")
 
 	def test_creation_timeIsNotANumber(self):
-		self.assertRaises(ValueError, JU.TestCase, "name", "status", "time", "classname")
+		testcase = JU.TestCase("name")
+		self.assertRaises(ValueError, testcase.setTime, "time")
 
 	def test_creation_timeIsNegative(self):
-		self.assertRaises(ValueError, JU.TestCase, "name", "status", "-1.0", "classname")
-
-	def test_attributes(self):
-		testcase = JU.TestCase("name", "status", "1", "classname")
-		self.assertEqual(testcase.attrib("name"), "name")
-		self.assertEqual(testcase.attrib("status"), "status")
-		self.assertEqual(testcase.attrib("time"), "1")
-		self.assertEqual(testcase.attrib("classname"), "classname")
-
+		testcase = JU.TestCase("name")
+		self.assertRaises(ValueError, testcase.setTime, "-1.0")
 
 class TestSuiteTest(unittest.TestCase):	
 	
@@ -27,18 +21,24 @@ class TestSuiteTest(unittest.TestCase):
 		self.assertRaises(TypeError, JU.TestSuite)
 
 	def test_addTestcase(self):
-		JU.TestSuite("name").appendTestCase(JU.TestCase("name", "status", "1", "classname"))
+		JU.TestSuite("name").appendTestCase(JU.TestCase("name"))
 
 	def test_time(self):
 		testsuite = JU.TestSuite("name")
-		testsuite.appendTestCase(JU.TestCase("name", "status", "0.3", "classname"))
-		self.assertEqual(float(testsuite.attrib("time")), 0.3)
-		testsuite.appendTestCase(JU.TestCase("name1", "status", "0.2", "classname"))
-		self.assertEqual(float(testsuite.attrib("time")), 0.5)
-		testsuite.appendTestCase(JU.TestCase("name2", "status", "9.3", "classname"))
-		self.assertEqual(float(testsuite.attrib("time")), 9.8)
-		testsuite.appendTestCase(JU.TestCase("name3", "status", "01.3", "classname"))
-		self.assertEqual(float(testsuite.attrib("time")), 11.1)
+		testcase = JU.TestCase("name")
+
+		testcase.setTime(0.3)
+		testsuite.appendTestCase(testcase)
+		self.assertEqual(float(testsuite._attrib("time")), 0.3)
+
+		testcase.setTime(2.3)
+		testsuite.appendTestCase(testcase)
+		self.assertEqual(float(testsuite._attrib("time")), 2.6)
+
+		testcase.setTime(1.1)
+		testsuite.appendTestCase(testcase)
+		self.assertEqual(float(testsuite._attrib("time")), 3.7)
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -29,10 +29,16 @@ class TestSuiteTest(unittest.TestCase):
 	def test_addTestcase(self):
 		JU.TestSuite("name").appendTestCase(JU.TestCase("name", "status", "1", "classname"))
 
-	def test_addTestcaseWithSameName(self):
+	def test_time(self):
 		testsuite = JU.TestSuite("name")
-		self.assertRaises(NameError, testsuite.appendTestCase, JU.TestCase("name", "status", "1", "classname"))
-
+		testsuite.appendTestCase(JU.TestCase("name", "status", "0.3", "classname"))
+		self.assertEqual(float(testsuite.attrib("time")), 0.3)
+		testsuite.appendTestCase(JU.TestCase("name1", "status", "0.2", "classname"))
+		self.assertEqual(float(testsuite.attrib("time")), 0.5)
+		testsuite.appendTestCase(JU.TestCase("name2", "status", "9.3", "classname"))
+		self.assertEqual(float(testsuite.attrib("time")), 9.8)
+		testsuite.appendTestCase(JU.TestCase("name3", "status", "01.3", "classname"))
+		self.assertEqual(float(testsuite.attrib("time")), 11.1)
 
 if __name__ == '__main__':
 	unittest.main()

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -1,0 +1,22 @@
+import unittest
+import junitoutput as JU
+
+class TestCaseTest(unittest.TestCase):
+
+	def test_creation(self):
+		JU.TestCase("name", "status", "1", "classname")
+
+	def test_creation_timeIsNotANumber(self):
+		self.assertRaises(ValueError, JU.TestCase, "name", "status", "time", "classname")
+
+class TestSuiteTest(unittest.TestCase):	
+	
+	def test_creation(self):
+		JU.TestSuite("testsuiteName")
+		self.assertRaises(TypeError, JU.TestSuite)
+
+	def test_addTestcase(self):
+		JU.TestSuite("name").appendTestCase(JU.TestCase("name", "status", "10", "classname"))
+
+if __name__ == '__main__':
+	unittest.main()

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -5,6 +5,7 @@ class TestCaseTest(unittest.TestCase):
 
 	def test_creation(self):
 		JU.TestCase("name", "status", "1", "classname")
+		JU.TestCase("name", "status", 1, "classname")
 
 	def test_creation_timeIsNotANumber(self):
 		self.assertRaises(ValueError, JU.TestCase, "name", "status", "time", "classname")

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -1,6 +1,7 @@
 import unittest
 import junitoutput as JU
 
+
 class TestCaseTest(unittest.TestCase):
 
 	def test_creation(self):
@@ -13,6 +14,7 @@ class TestCaseTest(unittest.TestCase):
 	def test_creation_timeIsNegative(self):
 		testcase = JU.TestCase("name")
 		self.assertRaises(ValueError, testcase.setTime, "-1.0")
+
 
 class TestSuiteTest(unittest.TestCase):	
 	
@@ -38,6 +40,13 @@ class TestSuiteTest(unittest.TestCase):
 		testcase.setTime(1.1)
 		testsuite.appendTestCase(testcase)
 		self.assertEqual(float(testsuite._attrib("time")), 3.7)
+
+
+class TestJUnitDocument(unittest.TestCase):
+	
+	def test_creation(self):
+		JU.JUnitDocument("name")
+		self.assertRaises(TypeError, JU.JUnitDocument)
 
 
 if __name__ == '__main__':

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -5,11 +5,17 @@ class TestCaseTest(unittest.TestCase):
 
 	def test_creation(self):
 		JU.TestCase("name", "status", "1", "classname")
-		JU.TestCase("name", "status", 1, "classname")
-		JU.TestCase("name", "status", 1.0, "classname")
 
 	def test_creation_timeIsNotANumber(self):
 		self.assertRaises(ValueError, JU.TestCase, "name", "status", "time", "classname")
+
+	def test_attributes(self):
+		testcase = JU.TestCase("name", "status", "1", "classname")
+		self.assertEqual(testcase.attrib("name"), "name")
+		self.assertEqual(testcase.attrib("status"), "status")
+		self.assertEqual(testcase.attrib("time"), "1")
+		self.assertEqual(testcase.attrib("classname"), "classname")
+
 
 class TestSuiteTest(unittest.TestCase):	
 	
@@ -18,7 +24,12 @@ class TestSuiteTest(unittest.TestCase):
 		self.assertRaises(TypeError, JU.TestSuite)
 
 	def test_addTestcase(self):
-		JU.TestSuite("name").appendTestCase(JU.TestCase("name", "status", "10", "classname"))
+		JU.TestSuite("name").appendTestCase(JU.TestCase("name", "status", "1", "classname"))
+
+	def test_addTestcaseWithSameName(self):
+		testsuite = JU.TestSuite("name")
+		self.assertRaises(NameError, testsuite.appendTestCase, JU.TestCase("name", "status", "1", "classname"))
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -4,10 +4,13 @@ import junitoutput as JU
 class TestCaseTest(unittest.TestCase):
 
 	def test_creation(self):
-		JU.TestCase("name", "status", "1", "classname")
+		JU.TestCase("name", "status", "1.0", "classname")
 
 	def test_creation_timeIsNotANumber(self):
 		self.assertRaises(ValueError, JU.TestCase, "name", "status", "time", "classname")
+
+	def test_creation_timeIsNegative(self):
+		self.assertRaises(ValueError, JU.TestCase, "name", "status", "-1.0", "classname")
 
 	def test_attributes(self):
 		testcase = JU.TestCase("name", "status", "1", "classname")

--- a/b2btest/junitoutputTest.py
+++ b/b2btest/junitoutputTest.py
@@ -6,6 +6,7 @@ class TestCaseTest(unittest.TestCase):
 	def test_creation(self):
 		JU.TestCase("name", "status", "1", "classname")
 		JU.TestCase("name", "status", 1, "classname")
+		JU.TestCase("name", "status", 1.0, "classname")
 
 	def test_creation_timeIsNotANumber(self):
 		self.assertRaises(ValueError, JU.TestCase, "name", "status", "time", "classname")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url = "https://github.com/vokimon/back2back",
 	packages=[
 		'b2btest',
-		'wavefile',
+		'wavefile_audiolab',
 		],
     )
 

--- a/wavefile_audiolab/__init__.py
+++ b/wavefile_audiolab/__init__.py
@@ -111,8 +111,11 @@ class WaveReader(object) :
 		assert data.shape[1] == self.channels
 		desired_read_length = data.shape[0] 
 		to_read_length = desired_read_length if self._readed_frames + desired_read_length <= self._info['frames'] else self._info['frames'] - self._readed_frames
-		data = self._sndfile.read_frames(to_read_length, dtype=data.dtype)
+		tmp_data = self._sndfile.read_frames(to_read_length, dtype=data.dtype)
+		for i in range(len(tmp_data)):
+			data[i] = tmp_data[i]
 		self._readed_frames += to_read_length
+#		print data
 		return to_read_length
 
 if __name__ == '__main__' :

--- a/wavefile_audiolab/__init__.py
+++ b/wavefile_audiolab/__init__.py
@@ -92,6 +92,7 @@ class WaveReader(object) :
 				'format' : sndfile_handler.format,
 				'frames' : sndfile_handler.nframes,
 				} # TODO: metadata not implemented
+		self._readed_frames = 0
 	def __enter__(self) :
 		return self
 	def __exit__(self,type,value,traceback) :
@@ -107,8 +108,12 @@ class WaveReader(object) :
 	def frames(self) : return self._info['frames']
 
 	def read(self, data) :
-		assert data.shape[1] == self.channels()
-		return self._sndfile.read_frames (data.shape[0], dtype=data.dtype)
+		assert data.shape[1] == self.channels
+		desired_read_length = data.shape[0] 
+		to_read_length = desired_read_length if self._readed_frames + desired_read_length <= self._info['frames'] else self._info['frames'] - self._readed_frames
+		data = self._sndfile.read_frames(to_read_length, dtype=data.dtype)
+		self._readed_frames += to_read_length
+		return to_read_length
 
 if __name__ == '__main__' :
 

--- a/wavefile_audiolab/__init__.py
+++ b/wavefile_audiolab/__init__.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python
+import numpy as np
+from scikits.audiolab import Sndfile, available_file_formats, available_encodings, Format
+
+
+"""
+class WaveMetadata(object) :
+	strings = [
+		'title',
+		'copyright',
+		'software',
+		'artist',
+		'comment',
+		'date',
+		'album',
+		'license',
+		'tracknumber',
+		'genre',
+	]
+	__slots__ = strings + [
+		'_sndfile',
+		]
+
+	def __init__(self, sndfile) :
+		self._sndfile = sndfile
+
+	def __dir__(self) :
+		return self.strings
+
+	def __getattr__(self, name) :
+		if name not in self.strings :
+			raise AttributeError(name)
+		stringid = self.strings.index(name)
+		return _lib.sf_get_string(self._sndfile, stringid)
+
+	def __setattr__(self, name, value) :
+		if name not in self.strings :
+			return object.__setattr__(self, name, value)
+
+		stringid = self.strings.index(name)
+		error = _lib.sf_set_string(self._sndfile, stringid, value)
+		if error : print ValueError(
+			self.strings[stringid],
+			error, _lib.sf_error_number(error))
+"""
+
+class WaveWriter(object) :
+	def __init__(self,
+				filename,
+				samplerate = 44100,
+				channels = 1,
+				format = Format('wav','float32'),
+				) :
+
+		self._info = {	'filename' : filename , 
+				'samplerate' : samplerate,
+				'channels' : channels,
+				'format' : format,
+				'frames' : 0,
+				} # TODO: metadata not implemented
+
+		self._sndfile = Sndfile(filename, 'w', format, channels, samplerate)
+		if not self._sndfile :
+			raise NameError('Sndfile error loading file %s' % filename)
+
+	def __enter__(self) :
+		return self
+	def __exit__(self, type, value, traceback) :
+		self._sndfile.sync()
+		self._sndfile.close()
+		if value: raise # ????
+
+	def write(self, data) :
+		nframes, channels = data.shape
+		assert channels == self._info['channels']
+		self._sndfile.write_frames(data)
+
+class WaveReader(object) :
+	def __init__(self,
+				filename,
+				samplerate = 0,
+				channels = 0,
+				file_format = 0,
+				) :
+		sndfile_handler = Sndfile (filename, 'r') 
+		if not sndfile_handler :
+			raise NameError('Sndfile error loading file %s' % filename)
+		self._sndfile = sndfile_handler
+		self._info = {	'filename' : filename , 
+				'samplerate' : sndfile_handler.samplerate,
+				'channels' : sndfile_handler.channels,
+				'format' : sndfile_handler.format,
+				'frames' : sndfile_handler.nframes,
+				} # TODO: metadata not implemented
+	def __enter__(self) :
+		return self
+	def __exit__(self,type,value,traceback) :
+		self._sndfile.close()
+		if value: raise # ???
+	@property
+	def channels(self) : return self._info['channels']
+	@property
+	def format(self) : return self._info['format']
+	@property
+	def samplerate(self) : return self._info['samplerate']
+	@property
+	def frames(self) : return self._info['frames']
+
+	def read(self, data) :
+		assert data.shape[1] == self.channels()
+		return self._sndfile.read_frames (data.shape[0], dtype=data.dtype)
+
+if __name__ == '__main__' :
+
+	with WaveWriter('lala.ogg', channels=2, format=Format('ogg','vorbis')) as w :
+		# TODO: Metadata is not working!
+		#w.metadata.title = "La casa perdida"
+		#w.metadata.artist = "Me"
+		data = np.zeros((512,2), np.float32)
+		for x in xrange(100) :
+			data[:,0] = (x*np.arange(512, dtype=np.float32)%512/512)
+			data[512-x:,1] =  1
+			data[:512-x,1] = -1
+			w.write(data)
+
+	import sys
+	import pyaudio
+	p = pyaudio.PyAudio()
+	with WaveReader('MamaLadilla-TuBar.ogg', channels=2) as r :
+		# open stream
+		stream = p.open(
+				format = pyaudio.paFloat32,
+				channels = r.channels,
+				rate = r.samplerate,
+				frames_per_buffer = 512,
+				output = True)
+		with WaveWriter('Elvis-float.wav', channels=r.channels, samplerate=r.samplerate) as w :
+			data = np.zeros((512,r.channels), np.float32)
+			nframes = r.read(data)
+			#print "Title:", r.metadata.title
+			#print "Artist:", r.metadata.artist
+			print "Channels:", r.channels
+			print "Format: 0x%x"%r.format
+			print "Sample Rate:", r.samplerate
+			while nframes :
+				sys.stdout.write(".")
+				sys.stdout.flush()
+				stream.write(data[:nframes,:], nframes)
+				w.write(data[:nframes]*.8)
+				nframes = r.read(data)
+	stream.close()
+
+
+
+
+


### PR DESCRIPTION
Hola vokimon.
You can find uses cases in the code.

It will be nice if you could add te support of JUnit xml output on file by a commandline option like:

--gtest_output=xml[:DIRECTORY_PATH/|:FILE_PATH]
      Generate an XML report in the given directory or with the given file
      name. FILE_PATH defaults to test_details.xml

It's the same of googletest framework.

Alex
